### PR TITLE
Add optional copy-on-inject so original DLLs stay free to rebuild

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ egui = "0.27"
 eframe = "0.27"
 egui_extras = "0.27"
 rfd = "0.14"
-sysinfo = "0.33.1"
 windows = { version = "0.60.0", features = [
     "Win32_Foundation",
     "Win32_System_Memory",
     "Win32_System_Threading",
     "Win32_System_Diagnostics_Debug",
+    "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_LibraryLoader",
     "Win32_UI_WindowsAndMessaging",
     "Win32_Graphics_Gdi",

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The goal is to make `DLL injection` accessible and straightforward without sacri
 *   **🔄 Auto-Refresh Option:** Keep the process list up-to-date automatically without manual refreshes.
 *   **📂 Easy DLL Management:** Add DLLs via a file dialog, manage them in a persistent list, and remove them when they're no longer needed.
 *   **🚀 One-Click Injection:** Injects the selected DLL into the target process using the reliable `CreateRemoteThread` and `LoadLibraryA` method.
+*   **📋 Copy on Inject:** Optionally inject a temporary DLL copy so the original build output remains free for rebuilding.
 *   **💾 Session Persistence:** Remembers your list of DLLs and the last selected application, so you can pick up right where you left off.
 *   **🎨 Modern Dark UI:** Built with Rust's immediate-mode `egui GUI` framework for a responsive, cross-platform feel.
 *   **🔔 Toast Notifications:** Get instant, non-intrusive feedback on injection success, warnings, or failures.

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ The goal is to make `DLL injection` accessible and straightforward without sacri
 
 *   **🔍 Smart Process Scanning:** Lists all running processes with their name, PID, and application icon for easy identification.
 *   **⚡ Real-time Filtering:** Instantly search the process list to find exactly what you're looking for.
-*   **🔄 Auto-Refresh Option:** Keep the process list up-to-date automatically without manual refreshes.
+*   **🔄 Live Process Tracking:** Uses lightweight native Windows snapshots to remove terminated processes and reacquire same-name replacements automatically.
 *   **📂 Easy DLL Management:** Add DLLs, select one or more with checkboxes, and manage them in a persistent list.
 *   **🚀 One-Click Injection:** Injects every selected DLL into the target process using the reliable `CreateRemoteThread` and `LoadLibraryA` method.
 *   **📋 Copy on Inject:** Optionally inject a temporary DLL copy so the original build output remains free for rebuilding.
-*   **💾 Session Persistence:** Remembers your DLL list, checked DLLs, and last selected application.
+*   **💾 Session Persistence:** Remembers your DLL list, checked DLLs, last selected application, and window placement.
 *   **🎨 Modern Dark UI:** Built with Rust's immediate-mode `egui GUI` framework for a responsive, cross-platform feel.
 *   **🔔 Toast Notifications:** Get instant, non-intrusive feedback on injection success, warnings, or failures.
 
@@ -98,8 +98,7 @@ The goal is to make `DLL injection` accessible and straightforward without sacri
 Fluffy Injector is built with a modern Rust ecosystem:
 
 *   **[egui](https://github.com/emilk/egui) & [eframe](https://github.com/emilk/egui/tree/master/crates/eframe):** For the immediate-mode graphical user interface.
-*   **[windows-rs](https://github.com/microsoft/windows-rs):** For safe, idiomatic bindings to the Windows APIs required for injection and icon extraction.
-*   **[sysinfo](https://github.com/GuillaumeGomez/sysinfo):** For cross-platform system information, used here for process scanning.
+*   **[windows-rs](https://github.com/microsoft/windows-rs):** For safe, idiomatic bindings to the Windows APIs required for live process tracking, injection, and icon extraction.
 *   **[rfd](https://github.com/PolyMeilex/rfd):** For native, platform-appropriate "open file" dialogs.
 *   **[Serde](https://serde.rs/):** For robust serialization/deserialization of the configuration file.
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ The goal is to make `DLL injection` accessible and straightforward without sacri
 *   **🔍 Smart Process Scanning:** Lists all running processes with their name, PID, and application icon for easy identification.
 *   **⚡ Real-time Filtering:** Instantly search the process list to find exactly what you're looking for.
 *   **🔄 Auto-Refresh Option:** Keep the process list up-to-date automatically without manual refreshes.
-*   **📂 Easy DLL Management:** Add DLLs via a file dialog, manage them in a persistent list, and remove them when they're no longer needed.
-*   **🚀 One-Click Injection:** Injects the selected DLL into the target process using the reliable `CreateRemoteThread` and `LoadLibraryA` method.
+*   **📂 Easy DLL Management:** Add DLLs, select one or more with checkboxes, and manage them in a persistent list.
+*   **🚀 One-Click Injection:** Injects every selected DLL into the target process using the reliable `CreateRemoteThread` and `LoadLibraryA` method.
 *   **📋 Copy on Inject:** Optionally inject a temporary DLL copy so the original build output remains free for rebuilding.
-*   **💾 Session Persistence:** Remembers your list of DLLs and the last selected application, so you can pick up right where you left off.
+*   **💾 Session Persistence:** Remembers your DLL list, checked DLLs, and last selected application.
 *   **🎨 Modern Dark UI:** Built with Rust's immediate-mode `egui GUI` framework for a responsive, cross-platform feel.
 *   **🔔 Toast Notifications:** Get instant, non-intrusive feedback on injection success, warnings, or failures.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,7 +5,7 @@ use crate::models::process::ProcessInfo;
 use crate::models::toast::{Toast, ToastLevel};
 use crate::ui;
 use eframe::egui::{ColorImage, Context, TextureHandle};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::time::{Duration, Instant};
 
@@ -39,8 +39,12 @@ impl InjectorApp {
     pub fn new(cc: &eframe::CreationContext<'_>) -> Self {
         let config = Config::load().unwrap_or_default();
         let mut dll_manager = DLLManager::new();
+        let selected_dlls: HashSet<&str> =
+            config.selected_dlls.iter().map(String::as_str).collect();
         for dll in &config.dlls {
+            let index = dll_manager.get_dlls().len();
             dll_manager.add(dll.clone());
+            dll_manager.set_selected(index, selected_dlls.contains(dll.as_str()));
         }
 
         let (background_tx, background_rx) = mpsc::channel();

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,6 +9,8 @@ use std::collections::{HashMap, HashSet};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::time::{Duration, Instant};
 
+const WINDOW_SAVE_DELAY: Duration = Duration::from_millis(500);
+
 pub enum BackgroundMessage {
     Processes(Vec<ProcessInfo>),
     Icon((u32, ColorImage)),
@@ -21,23 +23,21 @@ pub struct InjectorApp {
     pub dll_manager: DLLManager,
     pub config: Config,
     pub is_loading_processes: bool,
-    pub auto_refresh: bool,
     pub icon_cache: HashMap<u32, TextureHandle>,
     pub default_dll_texture: Option<TextureHandle>,
     pub toasts: Vec<Toast>,
-    
+
     // UI-specific state moved here
     pub process_search: String,
 
     // Private fields
     background_rx: Receiver<BackgroundMessage>,
     icon_tx: Sender<(u32, std::path::PathBuf)>,
-    last_refresh: Instant,
+    window_save_at: Option<Instant>,
 }
 
 impl InjectorApp {
-    pub fn new(cc: &eframe::CreationContext<'_>) -> Self {
-        let config = Config::load().unwrap_or_default();
+    pub fn new(cc: &eframe::CreationContext<'_>, config: Config) -> Self {
         let mut dll_manager = DLLManager::new();
         let selected_dlls: HashSet<&str> =
             config.selected_dlls.iter().map(String::as_str).collect();
@@ -69,9 +69,8 @@ impl InjectorApp {
             config,
             background_rx,
             icon_tx,
+            window_save_at: None,
             is_loading_processes: true,
-            auto_refresh: true,
-            last_refresh: Instant::now() - Duration::from_secs(10),
             icon_cache: HashMap::new(),
             default_dll_texture: None,
             toasts: Vec::new(),
@@ -79,7 +78,6 @@ impl InjectorApp {
         };
 
         app.load_default_dll_icon(&cc.egui_ctx);
-        app.try_select_last_app();
         app
     }
 
@@ -87,10 +85,7 @@ impl InjectorApp {
         while let Ok(message) = self.background_rx.try_recv() {
             match message {
                 BackgroundMessage::Processes(procs) => {
-                    self.processes = procs;
-                    self.is_loading_processes = false;
-                    self.try_select_last_app();
-                    self.request_missing_icons();
+                    self.update_processes(procs);
                 }
                 BackgroundMessage::Icon((pid, color_image)) => {
                     let texture =
@@ -101,13 +96,6 @@ impl InjectorApp {
         }
     }
 
-    pub fn refresh_processes(&mut self) {
-        if !self.is_loading_processes {
-            self.is_loading_processes = true;
-            self.last_refresh = Instant::now();
-        }
-    }
-
     fn request_missing_icons(&self) {
         for proc in &self.processes {
             if !proc.exe.as_os_str().is_empty() && !self.icon_cache.contains_key(&proc.pid) {
@@ -115,11 +103,60 @@ impl InjectorApp {
             }
         }
     }
-    
-    fn try_select_last_app(&mut self) {
-        if let Some(last_app_name) = &self.config.last_selected_app {
-            if let Some(proc) = self.processes.iter().find(|p| &p.name == last_app_name) {
-                self.selected_process = Some(proc.pid);
+
+    fn update_processes(&mut self, processes: Vec<ProcessInfo>) {
+        let live_pids: HashSet<u32> = processes.iter().map(|process| process.pid).collect();
+        self.icon_cache.retain(|pid, _| live_pids.contains(pid));
+        self.selected_process = resolve_process_selection(
+            &processes,
+            self.selected_process,
+            self.config.last_selected_app.as_deref(),
+        );
+        self.processes = processes;
+        self.is_loading_processes = false;
+        self.request_missing_icons();
+    }
+
+    fn track_window_geometry(&mut self, ctx: &Context) {
+        let geometry = ctx.input(|input| {
+            let viewport = input.viewport();
+            if viewport.minimized == Some(true)
+                || viewport.maximized == Some(true)
+                || viewport.fullscreen == Some(true)
+            {
+                return None;
+            }
+
+            let position = viewport.outer_rect?.min;
+            let size = viewport.inner_rect?.size();
+            Some((
+                [position.x.round(), position.y.round()],
+                [size.x.round(), size.y.round()],
+            ))
+        });
+        let now = Instant::now();
+
+        if let Some((position, size)) = geometry {
+            if self.config.window_position != Some(position)
+                || self.config.window_size != Some(size)
+            {
+                self.config.window_position = Some(position);
+                self.config.window_size = Some(size);
+                self.window_save_at = Some(now + WINDOW_SAVE_DELAY);
+            }
+        }
+
+        if let Some(save_at) = self.window_save_at {
+            if now >= save_at {
+                self.window_save_at = None;
+                if let Err(error) = self.config.save() {
+                    self.add_toast(
+                        ToastLevel::Error,
+                        format!("Failed to save window position: {}", error),
+                    );
+                }
+            } else {
+                ctx.request_repaint_after(save_at.saturating_duration_since(now));
             }
         }
     }
@@ -152,14 +189,68 @@ impl InjectorApp {
 impl eframe::App for InjectorApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         self.handle_background_updates(ctx);
-
-        if self.auto_refresh
-            && !self.is_loading_processes
-            && self.last_refresh.elapsed() > Duration::from_secs(5)
-        {
-            self.last_refresh = Instant::now();
-        }
-        
+        self.track_window_geometry(ctx);
         ui::show(ctx, self);
+    }
+
+    fn on_exit(&mut self, _gl: Option<&eframe::glow::Context>) {
+        let _ = self.config.save();
+    }
+}
+
+fn resolve_process_selection(
+    processes: &[ProcessInfo],
+    selected_pid: Option<u32>,
+    selected_name: Option<&str>,
+) -> Option<u32> {
+    if let Some(pid) = selected_pid {
+        let still_running = processes.iter().any(|process| {
+            process.pid == pid
+                && selected_name
+                    .map(|name| process.name.eq_ignore_ascii_case(name))
+                    .unwrap_or(true)
+        });
+        if still_running {
+            return Some(pid);
+        }
+    }
+
+    selected_name.and_then(|name| {
+        processes
+            .iter()
+            .find(|process| process.name.eq_ignore_ascii_case(name))
+            .map(|process| process.pid)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_process_selection, ProcessInfo};
+    use std::path::PathBuf;
+
+    fn process(name: &str, pid: u32) -> ProcessInfo {
+        ProcessInfo {
+            name: name.into(),
+            pid,
+            exe: PathBuf::new(),
+        }
+    }
+
+    #[test]
+    fn keeps_live_pid_and_reacquires_terminated_process_by_name() {
+        let processes = [process("game.exe", 10), process("game.exe", 20)];
+
+        assert_eq!(
+            resolve_process_selection(&processes, Some(20), Some("game.exe")),
+            Some(20)
+        );
+        assert_eq!(
+            resolve_process_selection(&processes, Some(99), Some("GAME.EXE")),
+            Some(10)
+        );
+        assert_eq!(
+            resolve_process_selection(&processes, Some(99), Some("missing.exe")),
+            None
+        );
     }
 }

--- a/src/core/injector.rs
+++ b/src/core/injector.rs
@@ -1,4 +1,6 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use windows::{
     core::PCSTR,
     Win32::System::Diagnostics::Debug::WriteProcessMemory,
@@ -7,7 +9,62 @@ use windows::{
     Win32::System::Threading::{CreateRemoteThread, OpenProcess, PROCESS_ALL_ACCESS},
 };
 
-pub fn inject_dll(process_id: u32, dll_path: &str) -> Result<()> {
+pub fn inject_dll(process_id: u32, dll_path: &str, copy_on_inject: bool) -> Result<()> {
+    let copy = copy_on_inject
+        .then(|| create_injection_copy(process_id, Path::new(dll_path)))
+        .transpose()?;
+    let path = copy
+        .as_deref()
+        .unwrap_or(Path::new(dll_path))
+        .to_str()
+        .context("DLL path is not valid UTF-8")?;
+    inject_dll_path(process_id, path).inspect_err(|_| {
+        if let Some(path) = &copy {
+            let _ = std::fs::remove_file(path);
+        }
+    })
+}
+
+fn create_injection_copy(process_id: u32, source: &Path) -> Result<PathBuf> {
+    if !source.is_file() {
+        bail!("DLL does not exist: {}", source.display());
+    }
+
+    let dir = std::env::temp_dir().join("fluffy-injector");
+    std::fs::create_dir_all(&dir).context("Failed to create temp DLL directory")?;
+    cleanup_stale_copies(&dir);
+
+    let stem = source.file_stem().and_then(|s| s.to_str()).unwrap_or("dll");
+    let ext = source.extension().and_then(|e| e.to_str()).unwrap_or("dll");
+    let id = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let dest = dir.join(format!("{stem}-{process_id}-{id}.{ext}"));
+    std::fs::copy(source, &dest).context("Failed to copy DLL for injection")?;
+    Ok(dest)
+}
+
+fn cleanup_stale_copies(dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let max_age = Duration::from_secs(24 * 60 * 60);
+    for entry in entries.flatten() {
+        let stale = entry
+            .metadata()
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .and_then(|t| t.elapsed().ok())
+            .is_some_and(|age| age >= max_age);
+        // Loaded DLLs stay locked on Windows; only unused copies are removed.
+        if stale {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
+fn inject_dll_path(process_id: u32, dll_path: &str) -> Result<()> {
     unsafe {
         let process_handle = OpenProcess(PROCESS_ALL_ACCESS, false, process_id)?;
         let dll_path_bytes = dll_path.as_bytes();
@@ -30,8 +87,7 @@ pub fn inject_dll(process_id: u32, dll_path: &str) -> Result<()> {
             Some(&mut bytes_written),
         )?;
         let kernel32_handle = GetModuleHandleA(PCSTR(b"kernel32.dll\0".as_ptr()))?;
-        let load_library_addr =
-            GetProcAddress(kernel32_handle, PCSTR(b"LoadLibraryA\0".as_ptr()));
+        let load_library_addr = GetProcAddress(kernel32_handle, PCSTR(b"LoadLibraryA\0".as_ptr()));
         if load_library_addr.is_none() {
             bail!("Could not find LoadLibraryA address.");
         }
@@ -45,5 +101,27 @@ pub fn inject_dll(process_id: u32, dll_path: &str) -> Result<()> {
             None,
         )?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::create_injection_copy;
+
+    #[test]
+    fn injection_copy_preserves_dll_contents() {
+        let source = std::env::temp_dir().join(format!(
+            "fluffy-injector-test-{}.dll",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        std::fs::write(&source, b"test").unwrap();
+        let copy = create_injection_copy(1, &source).unwrap();
+        assert_eq!(std::fs::read(&copy).unwrap(), b"test");
+        assert_ne!(copy, source);
+        let _ = std::fs::remove_file(source);
+        let _ = std::fs::remove_file(copy);
     }
 }

--- a/src/core/injector.rs
+++ b/src/core/injector.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Context, Result};
 use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 use windows::{
     core::PCSTR,
     Win32::System::Diagnostics::Debug::WriteProcessMemory,
@@ -32,7 +32,12 @@ fn create_injection_copy(process_id: u32, source: &Path) -> Result<PathBuf> {
 
     let dir = std::env::temp_dir().join("fluffy-injector");
     std::fs::create_dir_all(&dir).context("Failed to create temp DLL directory")?;
-    cleanup_stale_copies(&dir);
+    // Best-effort: locked (still-loaded) copies fail to delete and are left alone.
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
 
     let stem = source.file_stem().and_then(|s| s.to_str()).unwrap_or("dll");
     let ext = source.extension().and_then(|e| e.to_str()).unwrap_or("dll");
@@ -43,25 +48,6 @@ fn create_injection_copy(process_id: u32, source: &Path) -> Result<PathBuf> {
     let dest = dir.join(format!("{stem}-{process_id}-{id}.{ext}"));
     std::fs::copy(source, &dest).context("Failed to copy DLL for injection")?;
     Ok(dest)
-}
-
-fn cleanup_stale_copies(dir: &Path) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-    let max_age = Duration::from_secs(24 * 60 * 60);
-    for entry in entries.flatten() {
-        let stale = entry
-            .metadata()
-            .ok()
-            .and_then(|m| m.modified().ok())
-            .and_then(|t| t.elapsed().ok())
-            .is_some_and(|age| age >= max_age);
-        // Loaded DLLs stay locked on Windows; only unused copies are removed.
-        if stale {
-            let _ = std::fs::remove_file(entry.path());
-        }
-    }
 }
 
 fn inject_dll_path(process_id: u32, dll_path: &str) -> Result<()> {

--- a/src/core/process_scanner.rs
+++ b/src/core/process_scanner.rs
@@ -1,29 +1,132 @@
 use crate::app::BackgroundMessage;
 use crate::models::process::ProcessInfo;
 use eframe::egui::Context;
+use std::collections::{HashMap, HashSet};
+use std::ffi::OsString;
+use std::os::windows::ffi::OsStringExt;
+use std::path::PathBuf;
 use std::sync::mpsc::Sender;
 use std::time::Duration;
-use sysinfo::System;
+use windows::core::PWSTR;
+use windows::Win32::Foundation::{CloseHandle, HANDLE};
+use windows::Win32::System::Diagnostics::ToolHelp::{
+    CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W, TH32CS_SNAPPROCESS,
+};
+use windows::Win32::System::Threading::{
+    OpenProcess, QueryFullProcessImageNameW, PROCESS_NAME_WIN32, PROCESS_QUERY_LIMITED_INFORMATION,
+};
+
+const SCAN_INTERVAL: Duration = Duration::from_millis(500);
+const PATH_BUFFER_SIZE: usize = 32_768;
+
+struct OwnedHandle(HANDLE);
+
+impl Drop for OwnedHandle {
+    fn drop(&mut self) {
+        let _ = unsafe { CloseHandle(self.0) };
+    }
+}
 
 pub fn scan_loop(tx: Sender<BackgroundMessage>, ctx: Context) {
-    let mut sys = System::new_all();
-    loop {
-        sys.refresh_all();
-        
-        let processes: Vec<ProcessInfo> = sys
-            .processes()
-            .iter()
-            .map(|(pid, process)| ProcessInfo {
-                name: process.name().to_string_lossy().into_owned(),
-                pid: pid.as_u32(),
-                exe: process.exe().map(|p| p.to_path_buf()).unwrap_or_default(),
-            })
-            .collect();
+    let mut last_processes = None;
+    let mut path_cache = HashMap::new();
+    let mut path_buffer = vec![0; PATH_BUFFER_SIZE];
 
-        if tx.send(BackgroundMessage::Processes(processes)).is_err() {
+    loop {
+        if let Ok(processes) = scan_processes(&mut path_cache, &mut path_buffer) {
+            if last_processes.as_ref() != Some(&processes) {
+                last_processes = Some(processes.clone());
+                if tx.send(BackgroundMessage::Processes(processes)).is_err() {
+                    break;
+                }
+                ctx.request_repaint();
+            }
+        }
+        std::thread::sleep(SCAN_INTERVAL);
+    }
+}
+
+fn scan_processes(
+    path_cache: &mut HashMap<u32, (String, PathBuf)>,
+    path_buffer: &mut [u16],
+) -> windows::core::Result<Vec<ProcessInfo>> {
+    let snapshot = OwnedHandle(unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)? });
+    let mut entry = PROCESSENTRY32W {
+        dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+        ..Default::default()
+    };
+    let mut processes = Vec::new();
+    let mut live_pids = HashSet::new();
+
+    unsafe { Process32FirstW(snapshot.0, &mut entry)? };
+    loop {
+        let pid = entry.th32ProcessID;
+        let name_length = entry
+            .szExeFile
+            .iter()
+            .position(|&character| character == 0)
+            .unwrap_or(entry.szExeFile.len());
+        let name = String::from_utf16_lossy(&entry.szExeFile[..name_length]);
+        live_pids.insert(pid);
+
+        let exe = match path_cache.get(&pid) {
+            Some((cached_name, path)) if cached_name == &name => path.clone(),
+            _ => {
+                let path = query_process_path(pid, path_buffer);
+                path_cache.insert(pid, (name.clone(), path.clone()));
+                path
+            }
+        };
+        processes.push(ProcessInfo { name, pid, exe });
+
+        if unsafe { Process32NextW(snapshot.0, &mut entry) }.is_err() {
             break;
         }
-        ctx.request_repaint();
-        std::thread::sleep(Duration::from_secs(5));
+    }
+
+    path_cache.retain(|pid, _| live_pids.contains(pid));
+    processes.sort_unstable_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then_with(|| left.pid.cmp(&right.pid))
+    });
+    Ok(processes)
+}
+
+fn query_process_path(pid: u32, buffer: &mut [u16]) -> PathBuf {
+    let Ok(handle) = (unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid) }) else {
+        return PathBuf::new();
+    };
+    let handle = OwnedHandle(handle);
+    let mut length = buffer.len() as u32;
+    if unsafe {
+        QueryFullProcessImageNameW(
+            handle.0,
+            PROCESS_NAME_WIN32,
+            PWSTR(buffer.as_mut_ptr()),
+            &mut length,
+        )
+    }
+    .is_err()
+    {
+        return PathBuf::new();
+    }
+
+    PathBuf::from(OsString::from_wide(&buffer[..length as usize]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{scan_processes, HashMap, PATH_BUFFER_SIZE};
+
+    #[test]
+    fn native_snapshot_contains_current_process() {
+        let mut cache = HashMap::new();
+        let mut buffer = vec![0; PATH_BUFFER_SIZE];
+        let processes = scan_processes(&mut cache, &mut buffer).unwrap();
+
+        assert!(processes
+            .iter()
+            .any(|process| process.pid == std::process::id()));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,24 +6,31 @@ mod models;
 mod ui;
 
 use crate::app::InjectorApp;
+use crate::models::config::{Config, DEFAULT_WINDOW_SIZE, MIN_WINDOW_SIZE};
 use eframe::{icon_data, NativeOptions};
 use std::sync::Arc;
 
 fn main() -> eframe::Result<()> {
     let icon = icon_data::from_png_bytes(include_bytes!("../assets/icon.png"))
         .expect("Failed to load window icon from assets/icon.png");
+    let config = Config::load().unwrap_or_default();
+
+    let mut viewport = eframe::egui::ViewportBuilder::default()
+        .with_inner_size(config.saved_window_size().unwrap_or(DEFAULT_WINDOW_SIZE))
+        .with_min_inner_size(MIN_WINDOW_SIZE)
+        .with_icon(Arc::new(icon));
+    if let Some(position) = config.saved_window_position() {
+        viewport = viewport.with_position(position);
+    }
 
     let native_options = NativeOptions {
-        viewport: eframe::egui::ViewportBuilder::default()
-            .with_inner_size([800.0, 600.0])
-            .with_min_inner_size([600.0, 400.0])
-            .with_icon(Arc::new(icon)),
+        viewport,
         ..Default::default()
     };
 
     eframe::run_native(
         "Fluffy Injector",
         native_options,
-        Box::new(|cc| Box::new(InjectorApp::new(cc))),
+        Box::new(move |cc| Box::new(InjectorApp::new(cc, config))),
     )
 }

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -7,6 +7,8 @@ pub struct Config {
     pub dlls: Vec<String>,
     pub last_selected_app: Option<String>,
     #[serde(default)]
+    pub selected_dlls: Vec<String>,
+    #[serde(default)]
     pub copy_dll_on_inject: bool,
 }
 
@@ -32,9 +34,22 @@ mod tests {
     use super::Config;
 
     #[test]
-    fn missing_copy_setting_defaults_to_disabled() {
+    fn missing_new_settings_use_defaults() {
         let config: Config =
             serde_json::from_str(r#"{"dlls":[],"last_selected_app":null}"#).unwrap();
+        assert!(config.selected_dlls.is_empty());
         assert!(!config.copy_dll_on_inject);
+    }
+
+    #[test]
+    fn selected_dlls_round_trip() {
+        let config = Config {
+            selected_dlls: vec!["a.dll".into(), "b.dll".into()],
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let restored: Config = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(restored.selected_dlls, config.selected_dlls);
     }
 }

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -6,6 +6,8 @@ use std::path::Path;
 pub struct Config {
     pub dlls: Vec<String>,
     pub last_selected_app: Option<String>,
+    #[serde(default)]
+    pub copy_dll_on_inject: bool,
 }
 
 impl Config {
@@ -22,5 +24,17 @@ impl Config {
     pub fn save(&self) -> Result<()> {
         let data = serde_json::to_string_pretty(self).context("Failed to serialize config")?;
         std::fs::write("config.json", data).context("Failed to write config file")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Config;
+
+    #[test]
+    fn missing_copy_setting_defaults_to_disabled() {
+        let config: Config =
+            serde_json::from_str(r#"{"dlls":[],"last_selected_app":null}"#).unwrap();
+        assert!(!config.copy_dll_on_inject);
     }
 }

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -2,6 +2,9 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
+pub const DEFAULT_WINDOW_SIZE: [f32; 2] = [800.0, 600.0];
+pub const MIN_WINDOW_SIZE: [f32; 2] = [600.0, 400.0];
+
 #[derive(Serialize, Deserialize, Default)]
 pub struct Config {
     pub dlls: Vec<String>,
@@ -10,6 +13,10 @@ pub struct Config {
     pub selected_dlls: Vec<String>,
     #[serde(default)]
     pub copy_dll_on_inject: bool,
+    #[serde(default)]
+    pub window_position: Option<[f32; 2]>,
+    #[serde(default)]
+    pub window_size: Option<[f32; 2]>,
 }
 
 impl Config {
@@ -27,6 +34,20 @@ impl Config {
         let data = serde_json::to_string_pretty(self).context("Failed to serialize config")?;
         std::fs::write("config.json", data).context("Failed to write config file")
     }
+
+    pub fn saved_window_position(&self) -> Option<[f32; 2]> {
+        self.window_position
+            .filter(|position| position.iter().all(|value| value.is_finite()))
+    }
+
+    pub fn saved_window_size(&self) -> Option<[f32; 2]> {
+        self.window_size.filter(|size| {
+            size[0].is_finite()
+                && size[1].is_finite()
+                && size[0] >= MIN_WINDOW_SIZE[0]
+                && size[1] >= MIN_WINDOW_SIZE[1]
+        })
+    }
 }
 
 #[cfg(test)]
@@ -39,17 +60,35 @@ mod tests {
             serde_json::from_str(r#"{"dlls":[],"last_selected_app":null}"#).unwrap();
         assert!(config.selected_dlls.is_empty());
         assert!(!config.copy_dll_on_inject);
+        assert!(config.window_position.is_none());
+        assert!(config.window_size.is_none());
     }
 
     #[test]
-    fn selected_dlls_round_trip() {
+    fn persisted_settings_round_trip() {
         let config = Config {
             selected_dlls: vec!["a.dll".into(), "b.dll".into()],
+            window_position: Some([120.0, 80.0]),
+            window_size: Some([900.0, 700.0]),
             ..Default::default()
         };
         let json = serde_json::to_string(&config).unwrap();
         let restored: Config = serde_json::from_str(&json).unwrap();
 
         assert_eq!(restored.selected_dlls, config.selected_dlls);
+        assert_eq!(restored.window_position, config.window_position);
+        assert_eq!(restored.window_size, config.window_size);
+    }
+
+    #[test]
+    fn rejects_invalid_window_geometry() {
+        let config = Config {
+            window_position: Some([f32::NAN, 10.0]),
+            window_size: Some([100.0, 100.0]),
+            ..Default::default()
+        };
+
+        assert!(config.saved_window_position().is_none());
+        assert!(config.saved_window_size().is_none());
     }
 }

--- a/src/models/dll_manager.rs
+++ b/src/models/dll_manager.rs
@@ -1,7 +1,7 @@
 #[derive(Default)]
 pub struct DLLManager {
     dlls: Vec<String>,
-    selected: Option<usize>,
+    selected: Vec<bool>,
 }
 
 impl DLLManager {
@@ -11,34 +11,66 @@ impl DLLManager {
 
     pub fn add(&mut self, path: String) {
         self.dlls.push(path);
+        self.selected.push(false);
     }
 
-    pub fn remove(&mut self, index: usize) {
-        if index < self.dlls.len() {
-            self.dlls.remove(index);
-            if let Some(selected_idx) = self.selected {
-                if selected_idx == index {
-                    self.selected = None;
-                } else if selected_idx > index {
-                    self.selected = Some(selected_idx - 1);
-                }
-            }
-        }
+    pub fn remove_selected(&mut self) -> usize {
+        let removed = self.selected.iter().filter(|&&selected| selected).count();
+        let mut index = 0;
+        self.dlls.retain(|_| {
+            let keep = !self.selected[index];
+            index += 1;
+            keep
+        });
+        self.selected.retain(|selected| !*selected);
+        removed
     }
 
-    pub fn get_dlls(&self) -> &Vec<String> {
+    pub fn get_dlls(&self) -> &[String] {
         &self.dlls
     }
 
-    pub fn select(&mut self, index: Option<usize>) {
-        self.selected = index;
+    pub fn set_selected(&mut self, index: usize, selected: bool) {
+        if let Some(value) = self.selected.get_mut(index) {
+            *value = selected;
+        }
     }
 
-    pub fn selected_dll(&self) -> Option<usize> {
-        self.selected
+    pub fn is_selected(&self, index: usize) -> bool {
+        self.selected.get(index).copied().unwrap_or(false)
     }
 
-    pub fn selected_path(&self) -> Option<String> {
-        self.selected.map(|i| self.dlls[i].clone())
+    pub fn selected_count(&self) -> usize {
+        self.selected.iter().filter(|&&selected| selected).count()
+    }
+
+    pub fn selected_paths(&self) -> impl Iterator<Item = &str> {
+        self.dlls
+            .iter()
+            .zip(&self.selected)
+            .filter_map(|(path, &selected)| selected.then_some(path.as_str()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DLLManager;
+
+    #[test]
+    fn selects_and_removes_multiple_dlls() {
+        let mut manager = DLLManager::new();
+        for path in ["a.dll", "b.dll", "c.dll"] {
+            manager.add(path.into());
+        }
+        manager.set_selected(0, true);
+        manager.set_selected(2, true);
+
+        assert_eq!(
+            manager.selected_paths().collect::<Vec<_>>(),
+            ["a.dll", "c.dll"]
+        );
+        assert_eq!(manager.remove_selected(), 2);
+        assert_eq!(manager.get_dlls(), ["b.dll"]);
+        assert_eq!(manager.selected_count(), 0);
     }
 }

--- a/src/models/process.rs
+++ b/src/models/process.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProcessInfo {
     pub name: String,
     pub pid: u32,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -22,7 +22,12 @@ fn draw_top_bar(ctx: &egui::Context, app: &InjectorApp) {
             ui.horizontal(|ui| {
                 let process_label = match app.selected_process_name() {
                     Some(name) => format!("Selected Process: {} ({})", name, app.selected_process.unwrap()),
-                    None => "Selected Process: None".to_string(),
+                    None => app
+                        .config
+                        .last_selected_app
+                        .as_ref()
+                        .map(|name| format!("Waiting for Process: {}", name))
+                        .unwrap_or_else(|| "Selected Process: None".to_string()),
                 };
                 ui.label(RichText::new(process_label).size(16.0).color(Color32::WHITE));
                 ui.add_space(20.0);
@@ -69,13 +74,6 @@ fn draw_process_panel(ui: &mut egui::Ui, app: &mut InjectorApp) {
         ui.text_edit_singleline(&mut app.process_search);
         ui.add_space(5.0);
         ui.separator();
-        ui.add_space(5.0);
-        ui.horizontal(|ui| {
-            if ui.button("🔄 Refresh").clicked() {
-                app.refresh_processes();
-            }
-            ui.checkbox(&mut app.auto_refresh, "Auto");
-        });
         ui.add_space(10.0);
         egui::ScrollArea::vertical().id_source("process_list").show(ui, |ui| {
             if app.is_loading_processes && app.processes.is_empty() {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,7 +15,7 @@ fn draw_top_bar(ctx: &egui::Context, app: &InjectorApp) {
         .frame(
             Frame::default()
                 .fill(Color32::from_rgb(30, 30, 30))
-                .stroke(egui::Stroke::new(1.0, Color32::from_gray(80)))
+                .stroke(egui::Stroke::new(1.0_f32, Color32::from_gray(80)))
                 .inner_margin(Margin::same(8.0)),
         )
         .show(ctx, |ui| {
@@ -28,10 +28,10 @@ fn draw_top_bar(ctx: &egui::Context, app: &InjectorApp) {
                 ui.add_space(20.0);
                 ui.separator();
                 ui.add_space(20.0);
-                let dll_label = match app.dll_manager.selected_path() {
-                    Some(path) => format!("Selected DLL: {}", std::path::Path::new(&path).file_name().unwrap_or_default().to_string_lossy()),
-                    None => "Selected DLL: None".to_string(),
-                };
+                let dll_label = format!(
+                    "Selected DLLs: {}",
+                    app.dll_manager.selected_count()
+                );
                 ui.label(RichText::new(dll_label).size(16.0).color(Color32::LIGHT_BLUE));
             });
         });
@@ -112,6 +112,7 @@ fn draw_process_panel(ui: &mut egui::Ui, app: &mut InjectorApp) {
 }
 
 fn draw_dll_panel(ui: &mut egui::Ui, app: &mut InjectorApp) {
+    let mut save_config = false;
     ui.vertical(|ui| {
         ui.add_space(10.0);
         ui.label(RichText::new("📂 DLLs").size(18.0).strong().color(Color32::WHITE));
@@ -121,7 +122,7 @@ fn draw_dll_panel(ui: &mut egui::Ui, app: &mut InjectorApp) {
 
         egui::ScrollArea::vertical().id_source("dll_list").show(ui, |ui| {
             for i in 0..app.dll_manager.get_dlls().len() {
-                let is_selected = app.dll_manager.selected_dll() == Some(i);
+                let mut is_selected = app.dll_manager.is_selected(i);
                 let file_name = std::path::Path::new(&app.dll_manager.get_dlls()[i])
                     .file_name()
                     .unwrap_or_default()
@@ -135,8 +136,9 @@ fn draw_dll_panel(ui: &mut egui::Ui, app: &mut InjectorApp) {
                         ui.label("❔");
                     }
                     
-                    if ui.selectable_label(is_selected, file_name).clicked() {
-                        app.dll_manager.select(Some(i));
+                    if ui.checkbox(&mut is_selected, file_name).changed() {
+                        app.dll_manager.set_selected(i, is_selected);
+                        save_config = true;
                     }
                 });
             }
@@ -151,9 +153,7 @@ fn draw_dll_panel(ui: &mut egui::Ui, app: &mut InjectorApp) {
             .on_hover_text("Keeps the original DLL free for rebuilding.")
             .changed()
         {
-            if let Err(e) = app.config.save() {
-                app.add_toast(ToastLevel::Error, format!("Failed to save config: {}", e));
-            }
+            save_config = true;
         }
         ui.add_space(10.0);
 
@@ -164,33 +164,86 @@ fn draw_dll_panel(ui: &mut egui::Ui, app: &mut InjectorApp) {
                     if !app.dll_manager.get_dlls().contains(&path) {
                         app.dll_manager.add(path.clone());
                         app.config.dlls.push(path);
-                        let _ = app.config.save();
+                        save_config = true;
                     } else {
                         app.add_toast(ToastLevel::Warning, "DLL is already in the list.");
                     }
                 }
             }
-            let inject_enabled = app.selected_process.is_some() && app.dll_manager.selected_dll().is_some();
-            if ui.add_enabled(inject_enabled, egui::Button::new("🚀 Inject DLL").min_size(button_size)).clicked() {
-                if let (Some(pid), Some(dll_path)) = (app.selected_process, app.dll_manager.selected_path()) {
-                    match injector::inject_dll(pid, &dll_path, app.config.copy_dll_on_inject) {
-                        Ok(_) => app.add_toast(ToastLevel::Success, "Injection successful!"),
-                        Err(e) => app.add_toast(ToastLevel::Error, format!("Injection failed: {}", e)),
+            let selected_count = app.dll_manager.selected_count();
+            let inject_enabled = app.selected_process.is_some() && selected_count > 0;
+            if ui
+                .add_enabled(
+                    inject_enabled,
+                    egui::Button::new("🚀 Inject").min_size(button_size),
+                )
+                .clicked()
+            {
+                if let Some(pid) = app.selected_process {
+                    let copy_on_inject = app.config.copy_dll_on_inject;
+                    let failures: Vec<String> = app
+                        .dll_manager
+                        .selected_paths()
+                        .filter_map(|dll_path| {
+                            injector::inject_dll(pid, dll_path, copy_on_inject)
+                                .err()
+                                .map(|error| {
+                                    let name = std::path::Path::new(dll_path)
+                                        .file_name()
+                                        .unwrap_or_default()
+                                        .to_string_lossy();
+                                    format!("{}: {}", name, error)
+                                })
+                        })
+                        .collect();
+
+                    if failures.is_empty() {
+                        app.add_toast(
+                            ToastLevel::Success,
+                            format!("Injected {} DLL(s).", selected_count),
+                        );
+                    } else {
+                        app.add_toast(
+                            ToastLevel::Error,
+                            format!(
+                                "Injected {}/{}. Failed: {}",
+                                selected_count - failures.len(),
+                                selected_count,
+                                failures.join("; ")
+                            ),
+                        );
                     }
                 }
             }
-            let remove_enabled = app.dll_manager.selected_dll().is_some();
-            if ui.add_enabled(remove_enabled, egui::Button::new("❌ Remove File").min_size(button_size)).clicked() {
-                if let Some(selected_index) = app.dll_manager.selected_dll() {
-                    app.dll_manager.remove(selected_index);
-                    app.config.dlls.remove(selected_index);
-                    let _ = app.config.save();
-                    app.add_toast(ToastLevel::Info, "DLL removed.");
-                }
+            if ui
+                .add_enabled(
+                    selected_count > 0,
+                    egui::Button::new("❌ Remove").min_size(button_size),
+                )
+                .clicked()
+            {
+                let removed = app.dll_manager.remove_selected();
+                app.config.dlls = app.dll_manager.get_dlls().to_vec();
+                save_config = true;
+                app.add_toast(ToastLevel::Info, format!("Removed {} DLL(s).", removed));
             }
         });
         ui.add_space(10.0);
     });
+
+    if save_config {
+        app.config.selected_dlls = app
+            .dll_manager
+            .selected_paths()
+            .map(str::to_owned)
+            .collect();
+        if let Err(error) = app.config.save() {
+            app.add_toast(
+                ToastLevel::Error,
+                format!("Failed to save config: {}", error),
+            );
+        }
+    }
 }
 
 fn draw_toasts(ctx: &egui::Context, app: &mut InjectorApp) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -146,6 +146,17 @@ fn draw_dll_panel(ui: &mut egui::Ui, app: &mut InjectorApp) {
         ui.separator();
         ui.add_space(10.0);
 
+        if ui
+            .checkbox(&mut app.config.copy_dll_on_inject, "Copy on inject")
+            .on_hover_text("Keeps the original DLL free for rebuilding.")
+            .changed()
+        {
+            if let Err(e) = app.config.save() {
+                app.add_toast(ToastLevel::Error, format!("Failed to save config: {}", e));
+            }
+        }
+        ui.add_space(10.0);
+
         ui.horizontal(|ui| {
             let button_size = Vec2::new(100.0, 35.0);
             if ui.add(egui::Button::new("➕ Add DLL").min_size(button_size)).clicked() {
@@ -162,7 +173,7 @@ fn draw_dll_panel(ui: &mut egui::Ui, app: &mut InjectorApp) {
             let inject_enabled = app.selected_process.is_some() && app.dll_manager.selected_dll().is_some();
             if ui.add_enabled(inject_enabled, egui::Button::new("🚀 Inject DLL").min_size(button_size)).clicked() {
                 if let (Some(pid), Some(dll_path)) = (app.selected_process, app.dll_manager.selected_path()) {
-                    match injector::inject_dll(pid, &dll_path) {
+                    match injector::inject_dll(pid, &dll_path, app.config.copy_dll_on_inject) {
                         Ok(_) => app.add_toast(ToastLevel::Success, "Injection successful!"),
                         Err(e) => app.add_toast(ToastLevel::Error, format!("Injection failed: {}", e)),
                     }


### PR DESCRIPTION
## Summary
- Adds a **Copy on inject** option that injects a temp copy of the DLL so the original file stays unlocked for rebuilding.
- Persists the setting in `config.json` (defaults to off for existing configs).
- Removes failed copies immediately and cleans up stale temp copies older than 24 hours.