### PR TITLE
chore: bump upload-artifact to v6

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust Auto Builder
+﻿name: Rust Auto Builder
 
 on:
   push:
@@ -18,7 +18,7 @@ jobs:
       - name: Build release
         run: cargo build --release
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
           name: release-build
           path: target/release/fluffy_injector.exe


### PR DESCRIPTION
## Summary
Bump `actions/upload-artifact` from v5 to v6 so the workflow runs on the Node 24 action runtime and the Node 20 deprecation warning goes away.